### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "hummus",
-  "version": "1.0.117",
+  "version": "1.0.117-lineaje-01",
   "description": "Create, read and modify PDF files and streams",
   "homepage": "http://pdfhummus.com/",
   "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "author": "Gal Kahana <gal.kahana@hotmail.com>",
   "main": "./hummus.js",
   "scripts": {
@@ -12,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/galkahana/HummusJS.git"
+    "url": "https://github.com/lineaje-labs-gos/HummusJS"
   },
   "keywords": [
     "pdf",


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
